### PR TITLE
Add destroy cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ INFO[0001] Creating view(your_dataset.your_view)
 bra bra bra ....
 ```
 
+Destroy all the views in the GCP project with `bqv destroy` command.
+
+```sh
+bqv destroy --projectID=your_project
+INFO[0001] Deleting view your_dataset.your_view
+```
+
 ## With parameter
 
 You can use the `query.sql` file as a template and replace the placeholders in it when you run `bqv apply`.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -24,8 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var projectID string
-
 // applyCmd represents the apply command
 var applyCmd = &cobra.Command{
 	Use:   "apply",

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -1,0 +1,50 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// destroyCmd represents the destroy command
+var destroyCmd = &cobra.Command{
+	Use:   "destroy",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("destroy called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(destroyCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// destroyCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// destroyCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var cfgFile string
 var baseDir string
 var verbose bool
 var paramFile string
+var projectID string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
本件のissue: #13 



WIPの段階でレビュワーに確認したいこと

1. Destroyコマンドの仕様ってこれであってますかね？
project idを指定するだけで、ディレクトリ配下のdataset.viewを全て削除してくれます。
```
> $ bqv destroy --projectID=xxxxxxxxxxxxxxxxxxx
INFO[0001] Deleting view sample01.sample_view01
```

2. apply.goで宣言されているグローバル変数project_idですが、今回僕が実装したdestroy.goでも同じ名前で利用したいです。こちらローカル変数にしていただくことって可能でしょうか？もしくはroot.goでグローバル変数として宣言してしまうのもアリかもしれません。 
