### PR TITLE
apply/plan column description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ go install github.com/k-kawa/bqv
 
 Or you can use `bqv` as a Docker image which is available at [kkawa/bqv](https://cloud.docker.com/repository/docker/kkawa/bqv)
 
-
 # How to use
 
 Make a directory based on the names of the dataset and the view that you want to create.
@@ -37,13 +36,18 @@ EOF
 ```
 
 (Optional) You can also make a `meta.json` file in it to describe the meta data of the view.
-The supported option is only `description` the value of which is to be the description of it for now.
+The supported option is `description` and `schema` the value of which is to be the description of it for now.
 (We want to suport more. see the [issues](https://github.com/k-kawa/bqv/issues)
 
 ```sh
 $ cat <<EOF > your_dataset/your_view/meta.json
 {
-    "description": "this is my awesome view!"
+    "description": "this is my awesome view!",
+    "schema": [
+        {"name": "my_column_name_1", "description": "your column description 1!!"},
+        {"name": "my_column_name_2", "description": "your column description 2!!"},
+        {"name": "my_column_name_3", "description": "your column description 3!!"}
+    ]
 }
 EOF
 ```
@@ -91,4 +95,3 @@ EOF
 # Run bqv apply with the parameters.json
 $ bqv apply --paramFile=parameters.json
 ```
-

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/k-kawa/bqv/bqv"
@@ -60,7 +62,16 @@ var planCmd = &cobra.Command{
 			if diff == nil {
 				continue
 			}
-			fmt.Printf("## %s.%s\n### Old\nDescription: %s\n```sql\n%s\n```\n### New\nDescription: %s\n```sql\n%s\n```", diff.DatasetName, diff.ViewName, diff.OldDescription, diff.OldViewQuery, diff.NewDescription, diff.NewViewQuery)
+			queryDiff := "A view query has no change."
+			if strings.Compare(diff.OldViewQuery, diff.NewViewQuery) != 0 {
+				queryDiff = "### Old\n```sql\n" + diff.OldViewQuery + "\n```\n### New\n```sql\n" + diff.NewViewQuery + "\n```\n"
+			}
+			fmt.Printf("## %s.%s\n%s\nmetadata update :%s\n",
+				diff.DatasetName,
+				diff.ViewName,
+				queryDiff,
+				strconv.FormatBool(diff.MetadataUpdateFlag),
+			)
 		}
 	},
 }


### PR DESCRIPTION
#10 
Parse schema fields from json file and update bigquery's table metadata. 
Update metadata with https://godoc.org/cloud.google.com/go/bigquery#Table.Update
Related change:
- change to metadata diff and plan show with boolean in stdout from with string.
- change to update view and metadata from delete/create.

You can update view and column description following:
```json:your_dataset/your_view/meta.json
{
    "description": "this is my awesome view!",
    "schema": [
        {"name": "my_column_name_1", "description": "your column description 1!!"},
        {"name": "my_column_name_2", "description": "your column description 2!!"},
        {"name": "my_column_name_3", "description": "your column description 3!!"}
    ]
}
```

You can see `plan` when only change metadata.
```sh
$ bqv plan
## your_dataset.your_view
A view query has no change.
metadata update :true
```